### PR TITLE
Fix admin delete page not deleting things correctly

### DIFF
--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -1,5 +1,6 @@
 // An array of all results
 var all_results = [];
+var display_results = 0;
 
 //
 // function: drawtable
@@ -43,6 +44,7 @@ function drawtable()
 function render_results(num_results)
 {
   var results = getresults(all_results, num_results);
+  display_results = num_results;
 
   var recent_res_template = $.templates("#adminTemplate");
   var htmlOutput = recent_res_template.render(results);
@@ -66,7 +68,7 @@ function remove_games()
 {
     var password = $("#password").val();
     var games_to_remove = "";
-    for (var id = 0; id < all_results.length; id++)
+    for (var id = all_results.length; id >= all_results.length - display_results; id--)
     {
         checkbox = document.getElementById("res_check_box_" + id)
         if ((checkbox != null) && (checkbox.checked == true))

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -67,13 +67,13 @@ function addClickHandlers()
 function remove_games()
 {
     var password = $("#password").val();
-    var games_to_remove = "";
-    for (var id = all_results.length; id >= all_results.length - display_results; id--)
+    var games_to_remove = [];
+    for (var id = all_results.length - 1; id >= all_results.length - display_results; id--)
     {
         checkbox = document.getElementById("res_check_box_" + id)
         if ((checkbox != null) && (checkbox.checked == true))
         {
-            games_to_remove += (id) + ","
+            games_to_remove.push(id)
         }
     }
     var request = new XMLHttpRequest();
@@ -82,7 +82,7 @@ function remove_games()
         startup();
         drawtable();
     };
-    request.send(games_to_remove);
+    request.send(games_to_remove.join(","));
     $("#password").val('');
     return request;
 }


### PR DESCRIPTION
Fixes Issue #60 
Problem here is that the deletes were sent in ascending order and so deleting an index changed all later indices. Fixed to provide the results to delete in descending order so the index is guaranteed to exist. Also fixed a bug in that we also sent a blank entry which hit an exception in the server.